### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -29,7 +29,7 @@ jobs:
         id: git_tag
         run: echo ::set-output name=GIT_TAG::${GITHUB_REF/refs\/tags\//}
       - name: Build and publish release Docker image
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: hsldevcom/transitdata-tests
           username: ${{ secrets.TRANSITDATA_DOCKERHUB_USER  }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore